### PR TITLE
Renamed title of extension, removing Avalonia

### DIFF
--- a/AvaloniaVS.VS2022/source.extension.vsixmanifest
+++ b/AvaloniaVS.VS2022/source.extension.vsixmanifest
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="AvaloniaVS-Lite" Version="11.9.1.2" Language="en-US" Publisher="Suess Labs" />
-        <DisplayName>Legacy Avalonia Viewer (Lite)</DisplayName>
-        <Description xml:space="preserve">Legacy previewer and templates for Avalonia (vs2022 and vs2026).</Description>
+        <Identity Id="AvaloniaVS-Lite" Version="11.9.1.3" Language="en-US" Publisher="Suess Labs" />
+        <DisplayName>Legacy AXAML Viewer</DisplayName>
+        <Description xml:space="preserve">Legacy Avalonia previewer and templates for AXAML and XAML files (vs2022 and vs2026).</Description>
         <License>license.md</License>
         <Icon>icon.ico</Icon>
     </Metadata>

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# Lite Avalonia Visual Studio Extension
+# Legacy Avalonia AXAML Viewer for Visual Studio Extension
 
 _This project is an independent derivative of Avalonia technology and is not endorsed by AvaloniaUI OÜ._ The fork preserves the legacy Avalonia Visual Studio Extension at git hash, `7bf4941`, providing only basic features.
 


### PR DESCRIPTION
As per #3 remove the name "Avalonia" from the Visual Studio's extension title so it appears in the catalog without it.

Renamed to 'Legacy AXAML Viewer' to comply with request.