### PR TITLE
Output and Publish Folders

### DIFF
--- a/AvaloniaVS.VS2022/AvaloniaVS.VS2022.csproj
+++ b/AvaloniaVS.VS2022/AvaloniaVS.VS2022.csproj
@@ -36,7 +36,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>..\output\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -44,7 +44,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>..\output\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/AvaloniaVS.VS2022/source.extension.vsixmanifest
+++ b/AvaloniaVS.VS2022/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="AvaloniaVS-Lite" Version="11.9.1.6" Language="en-US" Publisher="Suess Labs" />
+        <Identity Id="AvaloniaVS-Lite" Version="11.9.1.7" Language="en-US" Publisher="Suess Labs" />
         <DisplayName>AXAML Viewer</DisplayName>
         <Description xml:space="preserve">Avalonia previewer and templates for AXAML and XAML files (vs2022 and vs2026), based on the legacy extension.</Description>
         <License>license.md</License>

--- a/build.ps1
+++ b/build.ps1
@@ -1,9 +1,19 @@
 # Build script for generating release package
 
+Write-Output "Cleaning output folders..."
+
 if (Test-Path -Path "AvaloniaVS.VS2022\bin")
 {
   Remove-Item AvaloniaVS.VS2022\bin\* -Recurse -Force
 }
+
+if (Test-Path -Path "output\")
+{
+  Remove-Item output\* -Recurse -Force
+}
+
+# Clean both debug and release
+dotnet clean AvaloniaVSExt.slnx --configuration Release
 
 $VCToolsInstallDir = . "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -Latest -requires Microsoft.Component.MSBuild -property InstallationPath
 Write-Host "VCToolsInstallDir: $VCToolsInstallDir"
@@ -18,3 +28,17 @@ Write-Host "Building..."
 & $msBuildPath /restore `
                AvaloniaVSExt.slnx `
                /p:Configuration=Release
+
+# Publish
+Write-Output "Cleaning Publish folder.."
+
+if (Test-Path -Path "publish\")
+{
+  Remove-Item publish\* -Recurse -Force
+}
+else
+{
+  New-Item -Path '.\publish' -ItemType Directory
+}
+
+Move-Item -Path .\output\Release\AvaloniaVS.VS2022.vsix -Destination .\publish\AvaloniaVS.VS2022.vsix

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
-# Legacy Avalonia AXAML Viewer Visual Studio Extension
+# Avalonia AXAML Viewer Visual Studio Extension (Based on Legacy)
 
-Yes, the same Avalonia GUI Previewer and syntax highlighter that you've grown to love under the MIT license.
+Yes, the same Avalonia GUI Previewer and syntax highlighter that you've grown to love under the MIT license,  _**free and open source!**_
 
 <center><img width="495" height="523" alt="image" src="https://github.com/user-attachments/assets/ad3d429d-8d64-4d75-894c-f7487b830ca5" /></center>
 
@@ -9,7 +9,7 @@ The fork preserves the legacy Avalonia Visual Studio Extension at git hash, `7bf
 > For the latest ground-breaking features, use the official [AvaloniaVS extension](https://marketplace.visualstudio.com/items?itemName=AvaloniaTeam.AvaloniaVS).
 >
 > This fork is intended for those who need a simple visual designer for Avalonia. For instance, those creating simple apps or sandboxing Avalonia. _**We encourage you to support the official tooling.**_
-> 
+>
 > _This project is an independent derivative of Avalonia technology and is not endorsed by AvaloniaUI OÜ._
 
 [![2022 marketplace](https://img.shields.io/visual-studio-marketplace/v/SuessLabs.Avalonia-Lite-VS.svg?label=2022-Marketplace)](https://marketplace.visualstudio.com/items?itemName=SuessLabs.Avalonia-Lite-VS)
@@ -38,9 +38,14 @@ Avalonia Visual Studio extension adds such capabilities to your Visual Studio:
 - It bundles Avalonia templates in your Visual Studio.
 - Icons for axaml files.
 
+## Updates
+
+2025-11-23 - Unhiding the share "Anonymous Usage Analytics" checkbox. Disabled on the backend
+2025-11-20 - Better auto-completion
+
 ### VSIX packages for Visual Studio
 
-[Avalonia for Visual Studio 2022](https://marketplace.visualstudio.com/items?itemName=AvaloniaTeam.AvaloniaVS)
+[![2026 marketplace](https://img.shields.io/visual-studio-marketplace/v/SuessLabs.Avalonia-Lite-VS.svg?label=2026-Marketplace)](https://marketplace.visualstudio.com/items?itemName=SuessLabs.Avalonia-Lite-VS)
 
 For VS2017 and VS2019 you need to download another plugin [Avalonia for Visual Studio 2019](https://marketplace.visualstudio.com/items?itemName=AvaloniaTeam.AvaloniaforVisualStudio)
 
@@ -48,6 +53,11 @@ For VS2017 and VS2019 you need to download another plugin [Avalonia for Visual S
 - Latest Release supporting VS2017 is **11.2**
 
 If you are interested in VSCode extension, visit https://github.com/AvaloniaUI/AvaloniaVSCode.
+
+
+## Updates
+
+* 2025-11-20 - Better auto-completion
 
 ## Debugging
 


### PR DESCRIPTION
* Builds now saved to root folder's `output` and `publish` folder for cleaner output
* Updated readme notes with VS2026 badge and History